### PR TITLE
Remove Cleanup section from Cloud NGFW + SCM isolated lab guide

### DIFF
--- a/cloudngfw-scm-isolated/README.md
+++ b/cloudngfw-scm-isolated/README.md
@@ -239,12 +239,6 @@ The next part adds the cross-account IAM roles (via a CloudFormation template) a
 
 > &#8505; This is the natural place to see what the onboarding roles actually unlock: the core inspection above worked without them; decryption and CloudWatch logging do not.
 
-## 11. Cleanup
-
-- `terraform destroy` the lab VPC.
-- In SCM, delete the Cloud NGFW endpoints and the firewall resource.
-- Your QwikLabs account is recycled at the end of the workshop.
-
 ## References
 
 - *Cloud NGFW for AWS - Getting Started* (SCM onboarding, tenant V2, deployment-profile activation)


### PR DESCRIPTION
Removes the **Cleanup** section from `cloudngfw-scm-isolated/README.md`. The lab stack stays up for the workshop, so the teardown steps are not wanted in the guide. Single-file, deletion only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)