### PR TITLE
Fix: add SSM interface endpoints so Session Manager survives firewall deny

### DIFF
--- a/cloudngfw-scm-isolated/README.md
+++ b/cloudngfw-scm-isolated/README.md
@@ -175,7 +175,7 @@ This creates the Cloud NGFW endpoint in each `gwlbe` subnet and redirects the ap
 
 > &#8505; The apply pauses for about 2.5 minutes after creating the endpoint. A GWLB endpoint returns from creation in a `pending` state, and AWS rejects a route to it until it is `available`. The Terraform waits this out for you (`gwlbe_route_delay`).
 
-> &#9888; Cloud NGFW denies by default. The moment you insert it, both directions stop: the app servers lose internet (including Session Manager), and the ALB page stops loading (its targets go unhealthy) until you add allow policy in the next step. That is expected.
+> &#9888; Cloud NGFW denies by default. The moment you insert it, both directions stop: the app servers lose outbound internet and the ALB page stops loading (its targets go unhealthy) until you add allow policy in the next step. That is expected. Session Manager keeps working - it reaches SSM through private VPC endpoints, so you keep your shell even while the data plane is denied.
 
 > &#10067; At this exact moment (routes flipped, no policy yet), where would you see an app server's outbound request being dropped?
 
@@ -218,7 +218,7 @@ Inbound rule, internet clients reaching the app through the ALB:
 
 Test both directions:
 
-- Outbound: from an app server (Session Manager), `curl -s https://ifconfig.me` and browse a few sites. You get a NAT public IP back, and Session Manager itself stays connected (it egresses over `ssl`).
+- Outbound: from an app server (Session Manager), `curl -s https://ifconfig.me` and browse a few sites. You get a NAT public IP back. Session Manager stays connected throughout because it uses the private SSM VPC endpoints, independent of your firewall policy.
 - Inbound: browse to `http://<alb_dns_name>/` (`terraform output alb_dns_name`). The app's headers page loads, served through the firewall.
 - View logs: SCM -> Configurations -> Cloud NGFWs -> your firewall -> View Logs. You should see both the outbound and inbound sessions.
 

--- a/cloudngfw-scm-isolated/terraform/main.tf
+++ b/cloudngfw-scm-isolated/terraform/main.tf
@@ -423,3 +423,44 @@ resource "aws_route" "app_to_lb_fw" {
   vpc_endpoint_id        = aws_vpc_endpoint.gwlbe[each.key].id
   depends_on             = [time_sleep.gwlbe_ready]
 }
+
+# ---------------- SSM interface endpoints (management access independent of egress) ----------------
+# Without these the SSM agent reaches ssm / ssmmessages / ec2messages over the public
+# internet through the firewall + NAT, so any egress deny (deny-by-default, or an
+# outbound rule that does not match the agent's traffic) drops Session Manager. These
+# private interface endpoints keep SSM in-VPC: private DNS points the SSM service names
+# at ENIs in the VPC, so management access survives whatever the firewall policy does.
+resource "aws_security_group" "vpce" {
+  name        = "${var.name_prefix}vpce"
+  description = "SSM interface endpoints"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description = "HTTPS from within the VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  egress {
+    description = "All egress"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.name_prefix}vpce" }
+}
+
+resource "aws_vpc_endpoint" "ssm" {
+  for_each            = toset(["ssm", "ssmmessages", "ec2messages"])
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.${var.region}.${each.key}"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [for k, s in aws_subnet.app : s.id]
+  security_group_ids  = [aws_security_group.vpce.id]
+  private_dns_enabled = true
+  tags                = { Name = "${var.name_prefix}vpce-${each.key}" }
+}


### PR DESCRIPTION
## Problem (hit live during the workshop)

After inserting the Cloud NGFW, students lost Session Manager:
```
SSM Agent unable to acquire credentials ... Post "https://ssm.us-east-1.amazonaws.com/": dial tcp 13.217.78.180:443: i/o timeout
```
The SSM agent reaches `ssm` / `ssmmessages` / `ec2messages` over the **public** internet through the firewall + NAT, so deny-by-default (or an outbound rule that doesn't match the agent's traffic) drops it - and you can't get on the box to fix the policy.

## Fix

Add interface VPC endpoints for `ssm`, `ssmmessages`, `ec2messages` in the app subnets, with **private DNS** and a security group allowing `443` from the VPC. SSM now resolves to private ENIs and stays in-VPC, **independent of the firewall path** - so Session Manager keeps working no matter what the policy does. This is the standard SSM-over-private-endpoint pattern.

Validated live: all three endpoints reach `available` with private DNS enabled.

## Also

Fixes two guide notes that said Session Manager drops on firewall insert - it no longer does (you keep your shell while the data plane is denied, which is better for the hands-on flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)